### PR TITLE
fix missing SPM.swd field when running cvLME on unestimated models

### DIFF
--- a/batch_MA_cvLME_auto.m
+++ b/batch_MA_cvLME_auto.m
@@ -68,6 +68,11 @@ for i = 1:N
     for j = 1:M
         fprintf('   - Model %s (%d out of %d) ... ',MS.GLMs{j},j,M);
         load(MS.SPMs{i,j});                 % load SPM.mat
+        % update field in case GLM has not been estimated
+        if ~isfield(SPM, 'swd')
+            path = spm_fileparts(MS.SPMs{i,j});
+            SPM.swd = path;
+        end
         MA_cvLME_multi(SPM,[],[],AnC);      % calculate cvLME
         fprintf('successful!\n');
     end;


### PR DESCRIPTION
- this fix will update the content of SPM structure by adding the missing field when running the batch
 - I suspect that `MA_cvLME_multi.m` will still throw an error if it receives an unestimated SPM as argument.